### PR TITLE
Fix typo in interface

### DIFF
--- a/app/components/ColorItem/ColorItem.js
+++ b/app/components/ColorItem/ColorItem.js
@@ -56,7 +56,7 @@ class ColorItem extends Component {
           <div className="color-footer">
             <div className="instructions-container dislike" onClick={onDislike}>
               <span className="keyboard-button">D</span>
-              <span className="keyboard-text">Disike</span>
+              <span className="keyboard-text">Dislike</span>
             </div>
             <div className="instructions-container remove" onClick={onRemove}>
               <span className="keyboard-button">&#8592;</span>


### PR DESCRIPTION
### Overview

The interface has a small typo in _Dis**l**ike_

![defgthyzdzgt](https://cloud.githubusercontent.com/assets/1416801/16785416/43e9c940-488e-11e6-96ae-c69bf5e4b4ae.PNG)
